### PR TITLE
feat: automate conda-forge feedstock update PR with `bob update feedstock`

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,7 +15,6 @@ Getting started
 ===============
 
 
-
 - ``Formula`` to sort, filter, order formula(s).
 
 - ``Oliynyk`` to parse Oliynyk elemental property database (https://doi.org/10.1016/j.dib.2024.110178).

--- a/news/bob-update-feedstock.rst
+++ b/news/bob-update-feedstock.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Implement ``bob update feedstock`` to prepare a PR to conda-forge feedstock with SHA256 and version updated from PyPI.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}
 
+[project.scripts]
+package = "bobleesj.utils.app:main"
+
 [tool.codespell]
 exclude-file = ".codespell/ignore_lines.txt"
 ignore-words = ".codespell/ignore_words.txt"

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,3 +1,4 @@
 numpy
 pandas
 openpyxl
+click

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,3 +1,4 @@
 numpy
 pandas
 openpyxl
+click

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -18,15 +18,15 @@ BOB_CONFIG_FILE = "~/.bobrc"
 # config_file = Path(os.path.expandvars(config_file)).expanduser()
 # exist_config = config_file.exists()
 config = {
-        "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
-    }
+    "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
+}
+
 
 def update_feedstock():
     conda_forge.main(config)
 
 
 def main():
-    
 
     parser = ArgumentParser(
         description="Save time managing software packages."

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,10 +1,12 @@
 # import os
 from argparse import ArgumentParser
-# from pathlib import Path
 
 from bobleesj.utils.cli import conda_forge
 
-#FIXME: Implmement hidden config file for scalability
+# from pathlib import Path
+
+
+# FIXME: Implmement hidden config file for scalability
 BOB_CONFIG_FILE = "~/.bobrc"
 # config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
 # config_file = Path(os.path.expandvars(config_file)).expanduser()

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,19 +1,11 @@
-import os
+# import os
 from argparse import ArgumentParser
-from pathlib import Path
+# from pathlib import Path
 
 from bobleesj.utils.cli import conda_forge
 
+#FIXME: Implmement hidden config file for scalability
 BOB_CONFIG_FILE = "~/.bobrc"
-
-# Maintain 3 feedstocks:
-
-
-# Checkout main, stash any existing
-# changes, and pull the latest changes from the remote repository.
-# Make a pull request from from bobleesj/<version> to conda-forge/main
-
-
 # config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
 # config_file = Path(os.path.expandvars(config_file)).expanduser()
 # exist_config = config_file.exists()

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,0 +1,39 @@
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from bobleesj.utils.cli import conda_forge
+
+BOB_CONFIG_FILE = "~/.bobrc"
+
+# Maintain 3 feedstocks:
+
+
+# Checkout main, stash any existing
+# changes, and pull the latest changes from the remote repository.
+# Make a pull request from from bobleesj/<version> to conda-forge/main
+
+
+config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
+config_file = Path(os.path.expandvars(config_file)).expanduser()
+exist_config = config_file.exists()
+
+def update_feedstock():
+    conda_forge.main()
+
+def main():
+    parser = ArgumentParser(description="Save time managing software packages.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # "update" command
+    parser_update = subparsers.add_parser("update", help="Update repositories and packages.")
+    update_subparsers = parser_update.add_subparsers(dest="subcommand", required=True)
+
+    # "feedstock" subcommand under "update"
+    parser_feedstock = update_subparsers.add_parser("feedstock", help="Update a conda-forge feedstock with the latest version and SHA256 from PyPI.")
+    parser_feedstock.set_defaults(func=update_feedstock)
+
+    args = parser.parse_args()
+    args.func(args)
+
+if __name__ == "__main__":
+    main()

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,6 +1,7 @@
 import os
 from argparse import ArgumentParser
 from pathlib import Path
+
 from bobleesj.utils.cli import conda_forge
 
 BOB_CONFIG_FILE = "~/.bobrc"
@@ -17,23 +18,35 @@ config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
 config_file = Path(os.path.expandvars(config_file)).expanduser()
 exist_config = config_file.exists()
 
+
 def update_feedstock():
     conda_forge.main()
 
+
 def main():
-    parser = ArgumentParser(description="Save time managing software packages.")
+    parser = ArgumentParser(
+        description="Save time managing software packages."
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # "update" command
-    parser_update = subparsers.add_parser("update", help="Update repositories and packages.")
-    update_subparsers = parser_update.add_subparsers(dest="subcommand", required=True)
+    parser_update = subparsers.add_parser(
+        "update", help="Update repositories and packages."
+    )
+    update_subparsers = parser_update.add_subparsers(
+        dest="subcommand", required=True
+    )
 
     # "feedstock" subcommand under "update"
-    parser_feedstock = update_subparsers.add_parser("feedstock", help="Update a conda-forge feedstock with the latest version and SHA256 from PyPI.")
+    parser_feedstock = update_subparsers.add_parser(
+        "feedstock",
+        help="Update a conda-forge feedstock with the latest version and SHA256 from PyPI.",
+    )
     parser_feedstock.set_defaults(func=update_feedstock)
 
     args = parser.parse_args()
-    args.func(args)
+    args.func()
+
 
 if __name__ == "__main__":
     main()

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -14,16 +14,20 @@ BOB_CONFIG_FILE = "~/.bobrc"
 # Make a pull request from from bobleesj/<version> to conda-forge/main
 
 
-config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
-config_file = Path(os.path.expandvars(config_file)).expanduser()
-exist_config = config_file.exists()
-
+# config_file = os.environ.get("BOB_CONFIG_FILE", BOB_CONFIG_FILE)
+# config_file = Path(os.path.expandvars(config_file)).expanduser()
+# exist_config = config_file.exists()
+config = {
+        "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
+    }
 
 def update_feedstock():
-    conda_forge.main()
+    conda_forge.main(config)
 
 
 def main():
+    
+
     parser = ArgumentParser(
         description="Save time managing software packages."
     )
@@ -40,7 +44,8 @@ def main():
     # "feedstock" subcommand under "update"
     parser_feedstock = update_subparsers.add_parser(
         "feedstock",
-        help="Update a conda-forge feedstock with the latest version and SHA256 from PyPI.",
+        help="Prepare to create a PR to the conda-forge/main with updated "
+        "version and SHA256 in meta.yaml.",
     )
     parser_feedstock.set_defaults(func=update_feedstock)
 

--- a/src/bobleesj/utils/cli/api.py
+++ b/src/bobleesj/utils/cli/api.py
@@ -1,0 +1,28 @@
+
+def get_PyPI_version_SHA(package_name, count=1):
+    """Fetch the latest stable versions of the package and their SHA256 from PyPI."""
+    response = requests.get(f"https://pypi.org/pypi/{package_name}/json")
+    if response.status_code == 200:
+        data = response.json()
+
+        # Filter and sort versions: only stable
+        all_versions = [
+            v for v in data["releases"].keys()
+            if not parse_version(v).is_prerelease
+        ]
+        sorted_versions = sorted(all_versions, key=parse_version, reverse=True)[:count]
+
+        version_info = {}
+        for version in sorted_versions:
+            files = data["releases"][version]
+            for file in files:
+                if file["packagetype"] == "sdist":
+                    version_info[version] = file["digests"]["sha256"]
+                    break
+
+        return version_info
+    else:
+        raise ValueError(
+            f"No matching package found for {package_name} on PyPI. "
+            "Please check the name at https://pypi.org/project/"
+        )

--- a/src/bobleesj/utils/cli/api.py
+++ b/src/bobleesj/utils/cli/api.py
@@ -1,17 +1,20 @@
+import requests
+from packaging.version import parse as parse_version
+
 
 def get_PyPI_version_SHA(package_name, count=1):
-    """Fetch the latest stable versions of the package and their SHA256 from PyPI."""
+    """Fetch the latest stable versions of the package and their SHA256."""
     response = requests.get(f"https://pypi.org/pypi/{package_name}/json")
     if response.status_code == 200:
         data = response.json()
-
-        # Filter and sort versions: only stable
         all_versions = [
-            v for v in data["releases"].keys()
+            v
+            for v in data["releases"].keys()
             if not parse_version(v).is_prerelease
         ]
-        sorted_versions = sorted(all_versions, key=parse_version, reverse=True)[:count]
-
+        sorted_versions = sorted(
+            all_versions, key=parse_version, reverse=True
+        )[:count]
         version_info = {}
         for version in sorted_versions:
             files = data["releases"][version]

--- a/src/bobleesj/utils/cli/auth.py
+++ b/src/bobleesj/utils/cli/auth.py
@@ -1,0 +1,15 @@
+import subprocess
+
+def get_github_username():
+    """Get the GitHub username using the GitHub CLI."""
+    try:
+        username = subprocess.check_output(
+            ["gh", "api", "user", "--jq", ".login"], text=True
+        ).strip()
+        return username
+    except subprocess.CalledProcessError:
+        raise RuntimeError(
+            "Could not retrieve GitHub username using GitHub CLI. "
+            "Please make sure your local machine is authenticated with GitHub."
+        )
+

--- a/src/bobleesj/utils/cli/auth.py
+++ b/src/bobleesj/utils/cli/auth.py
@@ -1,5 +1,6 @@
 import subprocess
 
+
 def get_github_username():
     """Get the GitHub username using the GitHub CLI."""
     try:
@@ -12,4 +13,3 @@ def get_github_username():
             "Could not retrieve GitHub username using GitHub CLI. "
             "Please make sure your local machine is authenticated with GitHub."
         )
-

--- a/src/bobleesj/utils/cli/conda_forge.py
+++ b/src/bobleesj/utils/cli/conda_forge.py
@@ -7,8 +7,7 @@ from bobleesj.utils.cli.shell import run
 
 
 def _update_meta_yaml(meta_file_path, new_version, new_sha256):
-    """Update the meta.yaml file with the new version and SHA256 hash before
-    making a PR to the feedstock repository."""
+    """Update the meta.yaml file with the new version and SHA256."""
     with open(meta_file_path, "r") as file:
         lines = file.readlines()
 
@@ -46,7 +45,8 @@ def _run_gh_shell_command(
     # Run the PR create command in the appropriate directory
     run(pr_command, cwd=cwd)
 
-def main():
+
+def main(config):
     """This script streamlines the process of updating Python package versions
     and their corresponding SHA256 hashes in a meta.yaml file, followed by
     creating a PR in the GitHub feedstock repository.
@@ -54,9 +54,9 @@ def main():
     - The user is prompted to choose a feedstock directory.
     - The system prints the latest versions and SHA256 hashes from PyPI.
     - The user confirms the version to update.
-    - The user's GitHub username is fetched using the GitHub CLI for authentication.
+    - The user's GitHub username is fetched using GitHub CLI.
     - The meta.yaml file is updated with the new version and SHA256.
-    - These changes are committed and pushed to GitHub to <username>/<version> 
+    - These changes are committed and pushed to GitHub to <username>/<version>
     - A PR is created from to conda-forge/main.
     - The user then is prompted to use the pull request template from CLI
     - THe rest is done by the user, including re-rendering the feedstock.
@@ -64,6 +64,7 @@ def main():
     config = {
         "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
     }
+
     feedstock_path = config["feedstock_path"]
     feedstocks = [
         f
@@ -75,7 +76,7 @@ def main():
     if not feedstocks:
         raise ValueError(
             f"No feedstocks found in {feedstock_path}. "
-            "Please ensure you have cloned the feedstocks and set the correct path."
+            "Please ensure you have cloned feedstocks."
         )
 
     print("Available feedstocks:")
@@ -95,13 +96,13 @@ def main():
                 ),
             }
             print(
-                f"  {i}. {pkg_name}, {pkg_version}, SHA256: {pkg_sha256[:5]}..."
+                f"  {i}. {pkg_name}, {pkg_version}, SHA256: {pkg_sha256[:5]}.."
             )
         except ValueError:
             print(f"  {i}. {pkg_name}, [PyPI: Not Found]")
 
     choice = click.prompt(
-        "Enter the corressponding number of the feedstock you want to update",
+        "Enter the corresponding number of the feedstock you want to update",
         type=click.IntRange(1, len(feedstocks)),
     )
     selected = version_map[choice]

--- a/src/bobleesj/utils/cli/conda_forge.py
+++ b/src/bobleesj/utils/cli/conda_forge.py
@@ -1,0 +1,128 @@
+from os.path import dirname, exists, join
+import os
+import click
+import requests
+from click import confirm, prompt
+from bobleesj.utils.cli import auth
+from bobleesj.utils.cli import api
+from bobleesj.utils.cli.shell import run
+from packaging.version import parse as parse_version
+
+
+"""
+This script streamlines the process of updating Python package versions and
+their corresponding SHA256 hash in a meta.yaml file, followed by creating a
+PR into the GitHub feedstock repository.
+
+- The user is prompted to choose a feedstock directory
+- The system prints the latest versions and SHA256 hashes from PyPI
+- THe user confirms the version to udpate
+- Fetch the user's GitHub username using the GitHub CLI for authentication
+- Update the meta.yaml file with the new version and SHA256
+- Commit these changes, pushes them to GitHub
+- Create a PR from <username>/<version> to conda-forge/main
+- Opens the web browser to review the PR
+"""
+
+
+def _update_meta_yaml(meta_file_path, new_version, new_sha256):
+    """
+    Update the meta.yaml file with the new version and SHA256 hash
+    before making a PR to the feedstock repository.
+    """
+    with open(meta_file_path, "r") as file:
+        lines = file.readlines()
+
+    with open(meta_file_path, "w") as file:
+        for line in lines:
+            if "{%- set version =" in line:
+                line = f'{{%- set version = "{new_version}" -%}}\n'
+            elif "{% set version =" in line:
+                line = f'{{% set version = "{new_version}" %}}\n'
+            elif "sha256:" in line:
+                line = f"  sha256: {new_sha256}\n"
+            file.write(line)
+
+
+def _run_gh_shell_command(
+    cwd, meta_file_path, version, SHA256, username, pkg_name
+):
+    """
+    Create a PR from a branch name of <new_version>
+    to the main branch of the feedstock repository.
+    """
+    run("git stash", cwd=cwd) 
+    run("git checkout main", cwd=cwd)
+    run("git pull upstream main", cwd=cwd)
+    # Create and switch to a new branch named after the new version
+    run(f"git checkout -b {version}", cwd=cwd)
+    # Update the meta.yaml file with the new version and SHA256
+    _update_meta_yaml(meta_file_path, version, SHA256)
+    # Add the updated meta.yaml file to the staging area
+    run("git add recipe/meta.yaml", cwd=cwd)
+    # Commit the changes
+    run(f'git commit -m "release: update to {version}"', cwd=cwd)
+    # Push the new branch to your origin repository
+    run(f"git push origin {version}", cwd=cwd)
+    run(
+        f"gh repo set-default conda-forge/{pkg_name}-feedstock --branch {"main"}",
+        cwd=cwd,
+    )
+    pr_command = (
+        f"gh pr create --base main --head {username}:{version} "
+        f"--title 'Update meta.yaml to {version}' "
+        f"--body 'Updated meta.yaml to version {version} with SHA value of {SHA256}'"
+    )
+    # Run the PR create command in the appropriate directory
+    run(pr_command, cwd=cwd)
+
+
+def main():
+    config = {
+        "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
+    }
+    feedstock_path = config["feedstock_path"]
+    feedstocks = [
+        f for f in os.listdir(feedstock_path)
+        if f.endswith("-feedstock") and os.path.isdir(os.path.join(feedstock_path, f))
+    ]
+
+    if not feedstocks:
+        raise ValueError(
+            f"No feedstocks found in {feedstock_path}. "
+            "Please ensure you have cloned the feedstocks and set the correct path."
+        )
+
+    print("Available feedstocks:")
+    version_map = {}
+    for i, feedstock in enumerate(feedstocks, start=1):
+        pkg_name = feedstock.replace("-feedstock", "")
+        try:
+            pkg_pypi_data = api.get_PyPI_version_SHA(pkg_name, count=1)
+            pkg_version, pkg_sha256 = next(iter(pkg_pypi_data.items()))
+            version_map[i] = {
+                "package_name": pkg_name,
+                "version": pkg_version,
+                "sha256": pkg_sha256,
+                "feedstock_dir_path": os.path.join(feedstock_path, feedstock),
+                "meta_file_path": os.path.join(feedstock_path, feedstock, "recipe", "meta.yaml"),
+            }
+            print(f"  {i}. {pkg_name}, {pkg_version}, SHA256: {pkg_sha256[:5]}...")
+        except ValueError:
+            print(f"  {i}. {pkg_name}, [PyPI: Not Found]")
+
+
+    choice = click.prompt(
+        "Enter the number of the feedstock you want to update",
+        type=click.IntRange(1, len(feedstocks))
+    )
+    selected = version_map[choice]
+    username = auth.get_github_username()
+    _run_gh_shell_command(
+        selected["feedstock_dir_path"],
+        selected["meta_file_path"],
+        selected["version"],
+        selected["sha256"],
+        username,
+        selected["package_name"]
+    )

--- a/src/bobleesj/utils/cli/conda_forge.py
+++ b/src/bobleesj/utils/cli/conda_forge.py
@@ -1,35 +1,14 @@
-from os.path import dirname, exists, join
 import os
+
 import click
-import requests
-from click import confirm, prompt
-from bobleesj.utils.cli import auth
-from bobleesj.utils.cli import api
+
+from bobleesj.utils.cli import api, auth
 from bobleesj.utils.cli.shell import run
-from packaging.version import parse as parse_version
-
-
-"""
-This script streamlines the process of updating Python package versions and
-their corresponding SHA256 hash in a meta.yaml file, followed by creating a
-PR into the GitHub feedstock repository.
-
-- The user is prompted to choose a feedstock directory
-- The system prints the latest versions and SHA256 hashes from PyPI
-- THe user confirms the version to udpate
-- Fetch the user's GitHub username using the GitHub CLI for authentication
-- Update the meta.yaml file with the new version and SHA256
-- Commit these changes, pushes them to GitHub
-- Create a PR from <username>/<version> to conda-forge/main
-- Opens the web browser to review the PR
-"""
 
 
 def _update_meta_yaml(meta_file_path, new_version, new_sha256):
-    """
-    Update the meta.yaml file with the new version and SHA256 hash
-    before making a PR to the feedstock repository.
-    """
+    """Update the meta.yaml file with the new version and SHA256 hash before
+    making a PR to the feedstock repository."""
     with open(meta_file_path, "r") as file:
         lines = file.readlines()
 
@@ -47,44 +26,50 @@ def _update_meta_yaml(meta_file_path, new_version, new_sha256):
 def _run_gh_shell_command(
     cwd, meta_file_path, version, SHA256, username, pkg_name
 ):
-    """
-    Create a PR from a branch name of <new_version>
-    to the main branch of the feedstock repository.
-    """
-    run("git stash", cwd=cwd) 
+    """Create a PR from a branch name of <new_version> to upstream/main."""
+    run("git stash", cwd=cwd)
     run("git checkout main", cwd=cwd)
     run("git pull upstream main", cwd=cwd)
-    # Create and switch to a new branch named after the new version
     run(f"git checkout -b {version}", cwd=cwd)
-    # Update the meta.yaml file with the new version and SHA256
     _update_meta_yaml(meta_file_path, version, SHA256)
-    # Add the updated meta.yaml file to the staging area
     run("git add recipe/meta.yaml", cwd=cwd)
-    # Commit the changes
     run(f'git commit -m "release: update to {version}"', cwd=cwd)
-    # Push the new branch to your origin repository
     run(f"git push origin {version}", cwd=cwd)
     run(
-        f"gh repo set-default conda-forge/{pkg_name}-feedstock --branch {"main"}",
+        f"gh repo set-default conda-forge/{pkg_name}-feedstock",
         cwd=cwd,
     )
     pr_command = (
         f"gh pr create --base main --head {username}:{version} "
-        f"--title 'Update meta.yaml to {version}' "
-        f"--body 'Updated meta.yaml to version {version} with SHA value of {SHA256}'"
+        f"--title 'Release {version}' "
     )
     # Run the PR create command in the appropriate directory
     run(pr_command, cwd=cwd)
 
-
 def main():
+    """This script streamlines the process of updating Python package versions
+    and their corresponding SHA256 hashes in a meta.yaml file, followed by
+    creating a PR in the GitHub feedstock repository.
+
+    - The user is prompted to choose a feedstock directory.
+    - The system prints the latest versions and SHA256 hashes from PyPI.
+    - The user confirms the version to update.
+    - The user's GitHub username is fetched using the GitHub CLI for authentication.
+    - The meta.yaml file is updated with the new version and SHA256.
+    - These changes are committed and pushed to GitHub to <username>/<version> 
+    - A PR is created from to conda-forge/main.
+    - The user then is prompted to use the pull request template from CLI
+    - THe rest is done by the user, including re-rendering the feedstock.
+    """
     config = {
         "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
     }
     feedstock_path = config["feedstock_path"]
     feedstocks = [
-        f for f in os.listdir(feedstock_path)
-        if f.endswith("-feedstock") and os.path.isdir(os.path.join(feedstock_path, f))
+        f
+        for f in os.listdir(feedstock_path)
+        if f.endswith("-feedstock")
+        and os.path.isdir(os.path.join(feedstock_path, f))
     ]
 
     if not feedstocks:
@@ -105,16 +90,19 @@ def main():
                 "version": pkg_version,
                 "sha256": pkg_sha256,
                 "feedstock_dir_path": os.path.join(feedstock_path, feedstock),
-                "meta_file_path": os.path.join(feedstock_path, feedstock, "recipe", "meta.yaml"),
+                "meta_file_path": os.path.join(
+                    feedstock_path, feedstock, "recipe", "meta.yaml"
+                ),
             }
-            print(f"  {i}. {pkg_name}, {pkg_version}, SHA256: {pkg_sha256[:5]}...")
+            print(
+                f"  {i}. {pkg_name}, {pkg_version}, SHA256: {pkg_sha256[:5]}..."
+            )
         except ValueError:
             print(f"  {i}. {pkg_name}, [PyPI: Not Found]")
 
-
     choice = click.prompt(
-        "Enter the number of the feedstock you want to update",
-        type=click.IntRange(1, len(feedstocks))
+        "Enter the corressponding number of the feedstock you want to update",
+        type=click.IntRange(1, len(feedstocks)),
     )
     selected = version_map[choice]
     username = auth.get_github_username()
@@ -124,5 +112,5 @@ def main():
         selected["version"],
         selected["sha256"],
         username,
-        selected["package_name"]
+        selected["package_name"],
     )

--- a/src/bobleesj/utils/cli/shell.py
+++ b/src/bobleesj/utils/cli/shell.py
@@ -1,5 +1,6 @@
 import subprocess
 
+
 def run(command, cwd=None):
     """Run a shell command in the specified directory."""
     subprocess.run(

--- a/src/bobleesj/utils/cli/shell.py
+++ b/src/bobleesj/utils/cli/shell.py
@@ -1,0 +1,11 @@
+import subprocess
+
+def run(command, cwd=None):
+    """Run a shell command in the specified directory."""
+    subprocess.run(
+        command,
+        check=True,
+        shell=True,
+        text=True,
+        cwd=cwd,
+    )


### PR DESCRIPTION
### What problem does this PR address?

Closes #48 - I had to manually 1) open terminal 2) cd into the feedstock 3) git checkout main 4) git pull upstream main 5) checkout a new branch 6) update SHA256, version manually after visiting pypi 7) push to origin/<version>

This process is now automated using `bob update feedstock`

I have to say, this is really beautiful:

![Screenshot 2025-06-01 at 10 45 18 PM](https://github.com/user-attachments/assets/5539725a-077c-42dd-80fc-c367dfd789e0)


### What should the reviewer(s) do?

Review the changes. Merge it. 

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
