### PR TITLE
feat: implement `bob new create to streamline` news creation process

### DIFF
--- a/news/bob-news.rst
+++ b/news/bob-news.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Streamline news file creation process with ``bob add news -flag -m <news-message>`` entry point.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,7 +1,7 @@
 # import os
 from argparse import ArgumentParser
 
-from bobleesj.utils.cli import conda_forge
+from bobleesj.utils.cli import conda_forge, news
 
 # from pathlib import Path
 
@@ -15,27 +15,34 @@ config = {
     "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
 }
 
+# FIXME: implement `bob test package`
+
 
 def update_feedstock():
     conda_forge.main(config)
 
 
-def main():
+def add_news(args):
+    news.add_news_item(args)
 
+
+def add_nonews(args):
+    news.add_no_news_item(args)
+    print(f"Adding NO news with message: {args.message}")
+
+
+def main():
     parser = ArgumentParser(
         description="Save time managing software packages."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-
-    # "update" command
+    # --- Update Command ---
     parser_update = subparsers.add_parser(
         "update", help="Update repositories and packages."
     )
     update_subparsers = parser_update.add_subparsers(
         dest="subcommand", required=True
     )
-
-    # "feedstock" subcommand under "update"
     parser_feedstock = update_subparsers.add_parser(
         "feedstock",
         help="Prepare to create a PR to the conda-forge/main with updated "
@@ -43,8 +50,34 @@ def main():
     )
     parser_feedstock.set_defaults(func=update_feedstock)
 
+    # --- Add Command ---
+    parser_add = subparsers.add_parser("add", help="Add news entries.")
+    add_subparsers = parser_add.add_subparsers(
+        dest="subcommand", required=True
+    )
+
+    def add_news_flags(p):
+        p.add_argument("-m", "--message", required=True, help="News item.")
+        p.add_argument("-a", action="store_true", help="Added")
+        p.add_argument("-c", action="store_true", help="Changed")
+        p.add_argument("-d", action="store_true", help="Deprecated")
+        p.add_argument("-r", action="store_true", help="Removed")
+        p.add_argument("-f", action="store_true", help="Fixed")
+        p.add_argument("-s", action="store_true", help="Security")
+
+    parser_add_news = add_subparsers.add_parser(
+        "news", help="Add a news entry."
+    )
+    add_news_flags(parser_add_news)
+    parser_add_news.set_defaults(func=add_news)
+    parser_add_nonews = add_subparsers.add_parser(
+        "no-news", help="Add a no-news entry."
+    )
+    add_news_flags(parser_add_nonews)
+    parser_add_nonews.set_defaults(func=add_nonews)
+    # Parse and run
     args = parser.parse_args()
-    args.func()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/bobleesj/utils/cli/auth.py
+++ b/src/bobleesj/utils/cli/auth.py
@@ -13,3 +13,10 @@ def get_github_username():
             "Could not retrieve GitHub username using GitHub CLI. "
             "Please make sure your local machine is authenticated with GitHub."
         )
+
+
+def get_current_branch():
+    result = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+    )
+    return result.strip()

--- a/src/bobleesj/utils/cli/conda_forge.py
+++ b/src/bobleesj/utils/cli/conda_forge.py
@@ -61,9 +61,6 @@ def main(config):
     - The user then is prompted to use the pull request template from CLI
     - THe rest is done by the user, including re-rendering the feedstock.
     """
-    config = {
-        "feedstock_path": "/Users/macbook/downloads/dev/feedstocks",
-    }
 
     feedstock_path = config["feedstock_path"]
     feedstocks = [

--- a/src/bobleesj/utils/cli/news.py
+++ b/src/bobleesj/utils/cli/news.py
@@ -1,0 +1,121 @@
+import os
+import shutil
+
+from bobleesj.utils.cli import auth
+
+HEADER_MAP = {
+    "a": "**Added:**",
+    "c": "**Changed:**",
+    "d": "**Deprecated:**",
+    "r": "**Removed:**",
+    "f": "**Fixed:**",
+    "s": "**Security:**",
+}
+
+TEMPLATE_PATH = "news/TEMPLATE.rst"
+NEWS_DIR = "news"
+
+
+def ensure_news_file(branch):
+    path = os.path.join(NEWS_DIR, f"{branch}.rst")
+    if not os.path.exists(path):
+        shutil.copy(TEMPLATE_PATH, path)
+    return path
+
+
+def read_news_file(path):
+    with open(path, "r") as f:
+        return f.readlines()
+
+
+def write_news_file(path, lines):
+    with open(path, "w") as f:
+        f.writelines(lines)
+
+
+def insert_message_in_section(lines, section, message):
+    new_lines = []
+    inserted = False
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        new_lines.append(line)
+
+        if not inserted and stripped == section:
+            # Clean out placeholder and blank lines
+            j = i + 1
+            while j < len(lines) and lines[j].strip() in ("", "* <news item>"):
+                j += 1
+
+            new_lines.append("\n")
+            new_lines.append(f"* {message}\n")
+            if j >= len(lines) or lines[j].strip().startswith("**"):
+                new_lines.append("\n")
+            inserted = True
+            i = j - 1  # Skip cleared lines
+        i += 1
+
+    return ensure_section_spacing(new_lines)
+
+
+def insert_message_multiple_sections(lines, flags, message):
+    new_lines = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        new_lines.append(line)
+
+        for flag in flags:
+            if stripped == HEADER_MAP[flag]:
+                j = i + 1
+                while j < len(lines) and lines[j].strip() in (
+                    "",
+                    "* <news item>",
+                ):
+                    j += 1
+
+                new_lines.append("\n")
+                new_lines.append(f"* {message}\n")
+                if j >= len(lines) or lines[j].strip().startswith("**"):
+                    new_lines.append("\n")
+                i = j - 1
+        i += 1
+
+    return ensure_section_spacing(new_lines)
+
+
+def ensure_section_spacing(lines):
+    fixed_lines = []
+    for idx, line in enumerate(lines):
+        fixed_lines.append(line)
+        if line.strip().startswith("**") and idx + 1 < len(lines):
+            if lines[idx + 1].strip() != "":
+                fixed_lines.append("\n")
+    return fixed_lines
+
+
+def add_news_item(args):
+    message = args.message
+    flags_used = [flag for flag in HEADER_MAP if getattr(args, flag)]
+    branch = auth.get_current_branch()
+    path = ensure_news_file(branch)
+    lines = read_news_file(path)
+    updated = insert_message_multiple_sections(lines, flags_used, message)
+    write_news_file(path, updated)
+
+    print(f"Done! Appended news item to {path}")
+
+
+def add_no_news_item(args):
+    message = f"no news added: {args.message}"
+    branch = auth.get_current_branch()
+    path = ensure_news_file(branch)
+    lines = read_news_file(path)
+    updated = insert_message_in_section(lines, HEADER_MAP["a"], message)
+    write_news_file(path, updated)
+
+    print(f"Done! Appended 'no news' entry to {path}")


### PR DESCRIPTION
### What problem does this PR address?

I also love this feature. Writing news is so much simpler now by running

```
bob add news -a -m "This is a great awesome news for CHANGELOG.rst"
bob add news -a -m "This is anther awesome news for CHANGELOG.rst"
```

What are the flags? These are 

```
HEADER_MAP = {
    "a": "**Added:**",
    "c": "**Changed:**",
    "d": "**Deprecated:**",
    "r": "**Removed:**",
    "f": "**Fixed:**",
    "s": "**Security:**",
}
```

I am glad that all letters are unique.

### What should the reviewer(s) do?

Merge the code. 


- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
