### PR TITLE
feat: implement `bob test package` and `bob test release` to serve as local CI for release prep

### DIFF
--- a/news/bob-test-package.rst
+++ b/news/bob-test-package.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Implement ``bob test release`` so that the package check whether it can be released to PyPI after running ``twine check dist/*``.
+* Implement ``bob test package`` to create a new environment to test the package fully.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 dependencies = {file = ["requirements/pip.txt"]}
 
 [project.scripts]
-package = "bobleesj.utils.app:main"
+bob = "bobleesj.utils.app:main"
 
 [tool.codespell]
 exclude-file = ".codespell/ignore_lines.txt"

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,7 +1,7 @@
 # import os
 from argparse import ArgumentParser
 
-from bobleesj.utils.cli import conda_forge, news
+from bobleesj.utils.cli import conda_forge, news, test
 
 # from pathlib import Path
 
@@ -18,7 +18,15 @@ config = {
 # FIXME: implement `bob test package`
 
 
-def update_feedstock():
+def test_package(args):
+    test.build_pytest()
+
+
+def test_release(args):
+    test.build_check_release()
+
+
+def update_feedstock(args):
     conda_forge.main(config)
 
 
@@ -36,6 +44,25 @@ def main():
         description="Save time managing software packages."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    # --- Test command ---
+    parser_update = subparsers.add_parser(
+        "test", help="Test the package with a new conda environment."
+    )
+    update_subparsers = parser_update.add_subparsers(
+        dest="subcommand", required=True
+    )
+    parser_test_package = update_subparsers.add_parser(
+        "package",
+        help="Test the single package.",
+    )
+    parser_test_package.set_defaults(func=test_package)
+
+    parser_test_release = update_subparsers.add_parser(
+        "release",
+        help="Test the release condition for the package.",
+    )
+    parser_test_release.set_defaults(func=test_release)
+
     # --- Update Command ---
     parser_update = subparsers.add_parser(
         "update", help="Update repositories and packages."
@@ -50,7 +77,7 @@ def main():
     )
     parser_feedstock.set_defaults(func=update_feedstock)
 
-    # --- Add Command ---
+    # --- Add command ---
     parser_add = subparsers.add_parser("add", help="Add news entries.")
     add_subparsers = parser_add.add_subparsers(
         dest="subcommand", required=True
@@ -81,4 +108,12 @@ def main():
 
 
 if __name__ == "__main__":
+    """
+    Examples:
+    ---------
+    >>> bob test package
+    >>> bob update feedsetock
+    >>> bob add news -a -m "Add awesome news!"
+    >>> bob add no-news -m "A grammatical fix"
+    """
     main()

--- a/src/bobleesj/utils/cli/test.py
+++ b/src/bobleesj/utils/cli/test.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+
+
+def build_check_release(env_name="release-env"):
+    print("📦 Starting isolated build and check process...")
+    print(f"🧪 Creating a new environment: {env_name}")
+
+    command = f"""
+    mamba create -n {env_name} python=3.13 \\
+        --file requirements/test.txt \\
+        --file requirements/conda.txt \\
+        --file requirements/docs.txt -y && \\
+    source $(conda info --base)/etc/profile.d/conda.sh && \\
+    conda activate {env_name} && \\
+    pip install build twine && \\
+    pip install . --no-deps && \\
+    python -m build && twine check dist/*
+    """
+
+    try:
+        subprocess.run(command, shell=True, executable="/bin/bash", check=True)
+        print(
+            "✅ Build and check completed successfully in environment:",
+            env_name,
+        )
+    except subprocess.CalledProcessError as e:
+        print("❌ Build or check failed:")
+        print(e)
+
+
+def build_pytest():
+    """In a Python subprocess, you start with a blank shell so there is no
+    e.g., .bashrc available. The environment name is derived from the current
+    working directory.
+
+    - Create a new Python environment with mamba with Python 3.13
+    - Install all requirements
+    - Install the package
+    - Run pytest and pre-commit
+    - Run whether it is possible to release to PyPI
+    """
+    package_name = os.path.basename(os.getcwd())
+    env_name = f"{package_name}-env"
+
+    print(f"🧪 Testing package: {package_name}")
+    print(f"📦 Creating and using env: {env_name}")
+
+    command = f"""
+    mamba create -n {env_name} python=3.13 \\
+        --file requirements/test.txt \\
+        --file requirements/conda.txt \\
+        --file requirements/docs.txt -y && \\
+    source $(conda info --base)/etc/profile.d/conda.sh && \\
+    conda activate {env_name} && \\
+    pip install --no-deps -e . && \\
+    pip install pre-commit && \\
+    pytest && pre-commit run --all-files
+    """
+
+    try:
+        subprocess.run(command, shell=True, check=True, executable="/bin/bash")
+    except subprocess.CalledProcessError as e:
+        print("Error - Test pipeline failed.")
+        print(e)
+    else:
+        print("Good! All tests and checks passed.")


### PR DESCRIPTION
### What problem does this PR address?

Another great features that would save my time forward: 

`bob test package` and `bob test release`. We want to always start a new conda environment and test the package. But it often takes time to run it using GitHub Actions. We rather do this locally using mamba which takes just about 15-20 seconds compared to 3-4 minutes via GitHub ACtions

### What should the reviewer(s) do?

It's not perfect code yet. But it does the job and the functionality won't change much. So merge it.


- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.
