### PR TITLE
feat: Implement `bob create issues` to generate multiple issues across many repositories using `.bobrc`

### DIFF
--- a/news/bob-create-issues.rst
+++ b/news/bob-create-issues.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Implement bob create issues to generate issues across many repositories.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/bobleesj/utils/app.py
+++ b/src/bobleesj/utils/app.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser
 
-from bobleesj.utils.cli import delete, test
+from bobleesj.utils.cli import create, delete, test
 
 
 def setup_test_subcommands(subparsers):
@@ -10,7 +10,6 @@ def setup_test_subcommands(subparsers):
     test_subparsers = test_parser.add_subparsers(
         dest="subcommand", required=True
     )
-
     test_commands = {
         "package": ("Test the single package.", test.build_pytest),
         "release": (
@@ -18,10 +17,24 @@ def setup_test_subcommands(subparsers):
             test.build_check_release,
         ),
     }
-
     for name, (help_text, handler) in test_commands.items():
         subparser = test_subparsers.add_parser(name, help=help_text)
-        subparser.set_defaults(func=handler)  # Directly assign the function
+        subparser.set_defaults(func=handler)
+
+
+def setup_create_subcommands(subparsers):
+    create_parser = subparsers.add_parser(
+        "create", help="Create new issues, PRs, etc."
+    )
+    create_subparsers = create_parser.add_subparsers(
+        dest="subcommand", required=True
+    )
+    create_commands = {
+        "issues": ("Create issues.", create.issues),
+    }
+    for name, (help_text, handler) in create_commands.items():
+        subparser = create_subparsers.add_parser(name, help=help_text)
+        subparser.set_defaults(func=handler)
 
 
 def setup_delete_subcommands(subparsers):
@@ -31,17 +44,15 @@ def setup_delete_subcommands(subparsers):
     delete_subparsers = delete_parser.add_subparsers(
         dest="subcommand", required=True
     )
-
     delete_commands = {
         "local-branches": (
             "Delete all local branches.",
             delete.all_local_branches,
         ),
     }
-
     for name, (help_text, handler) in delete_commands.items():
         subparser = delete_subparsers.add_parser(name, help=help_text)
-        subparser.set_defaults(func=handler)  # Direct assignment
+        subparser.set_defaults(func=handler)
 
 
 def main():
@@ -52,6 +63,7 @@ def main():
 
     setup_test_subcommands(subparsers)
     setup_delete_subcommands(subparsers)
+    setup_create_subcommands(subparsers)
 
     args = parser.parse_args()
 

--- a/src/bobleesj/utils/cli/create.py
+++ b/src/bobleesj/utils/cli/create.py
@@ -1,14 +1,18 @@
-from bobleesj.utils.io import config
 import subprocess
 from pathlib import Path
+
+from bobleesj.utils.io import config
+
 
 def prompt_for_issue():
     title = input("Enter the title for the new issue: ")
     body = input("Enter the body for the new issue: ")
     return title, body
 
+
 def find_git_repos(root_dir):
     return [p.parent for p in Path(root_dir).rglob(".git")]
+
 
 def create_issue(repo_path, title, body):
     print(f"\nProcessing repository: {repo_path}")
@@ -16,11 +20,12 @@ def create_issue(repo_path, title, body):
         subprocess.run(
             ["gh", "issue", "create", "--title", title, "--body", body],
             cwd=repo_path,
-            check=True
+            check=True,
         )
         print("✅ Issue created.")
     except subprocess.CalledProcessError:
         print("❌ Failed to create issue.")
+
 
 def issues(args):
     root_dir = config.value("~/.bobrc", "dev_dir_path")

--- a/src/bobleesj/utils/cli/create.py
+++ b/src/bobleesj/utils/cli/create.py
@@ -1,0 +1,37 @@
+from bobleesj.utils.io import config
+import subprocess
+from pathlib import Path
+
+def prompt_for_issue():
+    title = input("Enter the title for the new issue: ")
+    body = input("Enter the body for the new issue: ")
+    return title, body
+
+def find_git_repos(root_dir):
+    return [p.parent for p in Path(root_dir).rglob(".git")]
+
+def create_issue(repo_path, title, body):
+    print(f"\nProcessing repository: {repo_path}")
+    try:
+        subprocess.run(
+            ["gh", "issue", "create", "--title", title, "--body", body],
+            cwd=repo_path,
+            check=True
+        )
+        print("✅ Issue created.")
+    except subprocess.CalledProcessError:
+        print("❌ Failed to create issue.")
+
+def issues(args):
+    root_dir = config.value("~/.bobrc", "dev_dir_path")
+    if not root_dir or not Path(root_dir).is_dir():
+        print(f"Error: '{root_dir}' is not a valid directory.")
+        return
+    title, body = prompt_for_issue()
+    repos = find_git_repos(root_dir)
+    if not repos:
+        print("No Git repositories found.")
+        return
+
+    for repo in repos:
+        create_issue(repo, title, body)

--- a/src/bobleesj/utils/io/config.py
+++ b/src/bobleesj/utils/io/config.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import json
+
+def read(file_path:str):
+    """Read the configuration file."""
+    config_path = Path(file_path).expanduser()
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"Configuration file {file_path} is not found. "
+            "Please try again after running 'touch {config_file}'."
+        )
+    with config_path.open() as f:
+        return json.load(f)
+
+
+def value(file_path:str, key:str):
+    """Given the key, get the value from the config JSON."""
+    value = read(file_path).get(key, None)
+    if value is None:
+        raise ValueError(
+            f"No '{key}' is found in your config file."
+        )
+    return value

--- a/src/bobleesj/utils/io/config.py
+++ b/src/bobleesj/utils/io/config.py
@@ -1,7 +1,8 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
-def read(file_path:str):
+
+def read(file_path: str):
     """Read the configuration file."""
     config_path = Path(file_path).expanduser()
     if not config_path.exists():
@@ -13,11 +14,9 @@ def read(file_path:str):
         return json.load(f)
 
 
-def value(file_path:str, key:str):
+def value(file_path: str, key: str):
     """Given the key, get the value from the config JSON."""
     value = read(file_path).get(key, None)
     if value is None:
-        raise ValueError(
-            f"No '{key}' is found in your config file."
-        )
+        raise ValueError(f"No '{key}' is found in your config file.")
     return value


### PR DESCRIPTION
### What problem does this PR address?

Closes https://github.com/bobleesj/bobleesj.utils/issues/58
Closes https://github.com/bobleesj/bobleesj.utils/issues/71

I also love this feature. Ensure `.bobrc` is created:

```
{
    "dev_dir_path": "/Users/macbook/downloads/dev/bobleesj"
}
```

Then, run the following:

```
(bob-env) macbook@Macbook-Air-327 bobleesj.utils % bob create issues
Enter the title for the new issue: chore: ensure README and documentation clearly acknowledges scikit-package tooling
Enter the body for the new issue: Same as the title.

Processing repository: /Users/macbook/downloads/dev/bobleesj/bobleesj.github.io

Creating issue in bobleesj/bobleesj.github.io

https://github.com/bobleesj/bobleesj.github.io/issues/9
✅ Issue created.

Processing repository: /Users/macbook/downloads/dev/bobleesj/CAF

Creating issue in bobleesj/composition-analyzer-featurizer

https://github.com/bobleesj/composition-analyzer-featurizer/issues/41
✅ Issue created.

Processing repository: /Users/macbook/downloads/dev/bobleesj/bobleesj.utils

Creating issue in bobleesj/bobleesj.utils

https://github.com/bobleesj/bobleesj.utils/issues/72
✅ Issue created.

Processing repository: /Users/macbook/downloads/dev/bobleesj/SAF
...
```

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.
